### PR TITLE
Some fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ spin = "0.9.2"
 # log is used for logging in tests.
 log = "0.4"
 # test-env-log allows `RUST_LOG=...` to output test logs when tests fail.
-test-env-log = "0.2"
+test-log = "0.2"
 # env_logger is required for test-env-log.
 env_logger = "0.9.0"
 # We use random numbers to do some stress tests.

--- a/src/allocators.rs
+++ b/src/allocators.rs
@@ -471,7 +471,7 @@ impl HeapGrower for ToyHeap {
 mod tests {
     use super::*;
 
-    use test_env_log::test;
+    use test_log::test;
 
     #[test]
     fn test_basic() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![cfg_attr(not(feature = "use_libc"), feature(asm))]
 
 //! A simple memory allocator, written for educational purposes.
 //!

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -3,7 +3,7 @@
 ///
 /// The constants were taken from sys/mman.h, and have been tested on osx and
 /// linux.
-
+use core::arch::asm;
 //============================================================
 // System call code
 #[cfg(target_os = "macos")]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -50,6 +50,12 @@ pub struct MmapError {
     code: i64,
 }
 
+impl MmapError {
+    pub fn code(&self) -> i64 {
+        self.code
+    }
+}
+
 #[cfg(all(not(feature = "use_libc"), target_os = "linux"))]
 pub unsafe fn mmap(
     addr: *mut u8,

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -131,7 +131,7 @@ pub unsafe fn mmap(
 mod tests {
     use super::*;
 
-    use test_env_log::test;
+    use test_log::test;
 
     #[test]
     fn test_mmap() {

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -6,7 +6,7 @@ use basic_allocator::allocators::{RawAlloc, ToyHeap};
 use rand::distributions::Distribution;
 use rand::seq::SliceRandom;
 use rand::{RngCore, SeedableRng};
-use test_env_log::test;
+use test_log::test;
 
 #[test]
 fn test_stress() {


### PR DESCRIPTION
Added some fixes based on Rust compiler warnings.
- The import has been modified because the asm macro has been stable.
- Test-env-log has been deprecated. Use  test-log instead.
- Make use of variables that are unused.