### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ errno = {version = "0.2", optional = true}
 # Static assertions check that our assumptions are valid at compile-time
 static_assertions = "1.1"
 # A spin lock is used to protect the allocator in a multi-threaded capacity.
-spin = "0.9.2"
+spin = "0.9.8"
 
 [dev-dependencies]
 # log is used for logging in tests.


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)